### PR TITLE
fix: Make ACM work with Workload Identity

### DIFF
--- a/catalog/acm/README.md
+++ b/catalog/acm/README.md
@@ -1,0 +1,90 @@
+# GKE ACM blueprint
+
+A GKEHub Membership and ACM enrollment blueprint for Config Sync and Policy Controller for a pre-provisioned GKE cluster
+
+## Setters
+
+```
+Setter                    Usages
+auditIntervalSeconds      2
+cluster-name              5
+exemptableNamespaces      2
+feature-membership-name   2
+feature-name              3
+gcpServiceAccountEmail    2
+location                  3
+logDeniesEnabled          2
+membership-name           3
+platform-namespace        6
+platform-project-id       10
+policyDir                 2
+referentialRulesEnabled   2
+sourceFormat              2
+syncBranch                2
+syncRepo                  2
+syncRev                   2
+syncWaitSecs              2
+templateLibraryInstalled  2
+```
+
+## Sub-packages
+
+This package has no sub-packages.
+
+## Resources
+
+```
+File                     APIVersion                                  Kind                     Name                                     Namespace
+acm-membership-api.yaml  serviceusage.cnrm.cloud.google.com/v1beta1  Service                  platform-project-id-cluster-name-acm     platform-namespace
+acm-membership-api.yaml  serviceusage.cnrm.cloud.google.com/v1beta1  Service                  platform-project-id-cluster-name-gkehub  platform-namespace
+config-mgmt-csr.yaml     gkehub.cnrm.cloud.google.com/v1beta1        GKEHubFeatureMembership  feature-membership-name                  platform-namespace
+config-mgmt.yaml         gkehub.cnrm.cloud.google.com/v1beta1        GKEHubFeature            feature-name                             platform-namespace
+membership.yaml          gkehub.cnrm.cloud.google.com/v1beta1        GKEHubMembership         membership-name                          platform-namespace
+```
+
+## Resource References
+
+- [GKEHubFeatureMembership](https://cloud.google.com/config-connector/docs/reference/resource-docs/gkehub/gkehubfeaturemembership)
+- [GKEHubFeature](https://cloud.google.com/config-connector/docs/reference/resource-docs/gkehub/gkehubfeature)
+- [GKEHubMembership](https://cloud.google.com/config-connector/docs/reference/resource-docs/gkehub/gkehubmembership)
+- [Service](https://cloud.google.com/config-connector/docs/reference/resource-docs/serviceusage/service)
+
+## Usage
+
+1.  Clone the package:
+    ```
+    kpt pkg get https://github.com/GoogleCloudPlatform/blueprints.git/catalog/acm@${VERSION}
+    ```
+    Replace `${VERSION}` with the desired repo branch or tag
+    (for example, `main`).
+
+1.  Move into the local package:
+    ```
+    cd "./acm/"
+    ```
+
+1.  Edit the function config file(s):
+    - setters.yaml
+
+1.  Execute the function pipeline
+    ```
+    kpt fn render
+    ```
+
+1.  Initialize the resource inventory
+    ```
+    kpt live init --namespace ${NAMESPACE}"
+    ```
+    Replace `${NAMESPACE}` with the namespace in which to manage
+    the inventory ResourceGroup (for example, `config-control`).
+
+1.  Apply the package resources to your cluster
+    ```
+    kpt live apply
+    ```
+
+1.  Wait for the resources to be ready
+    ```
+    kpt live status --output table --poll-until current
+    ```
+

--- a/catalog/acm/config-mgmt-csr.yaml
+++ b/catalog/acm/config-mgmt-csr.yaml
@@ -23,7 +23,7 @@ spec:
   membershipRef:
     name: membership-name # kpt-set: acm-mem-${cluster-name}
   featureRef:
-    name: feature-name # kpt-set: ${feature-name}
+    name: feature-name # kpt-set: gke-acm-config-mgmt-${cluster-name}
   configmanagement:
     version: 1.9.0
     configSync:

--- a/catalog/acm/config-mgmt-csr.yaml
+++ b/catalog/acm/config-mgmt-csr.yaml
@@ -13,17 +13,17 @@
 # limitations under the License.
 apiVersion: gkehub.cnrm.cloud.google.com/v1beta1
 kind: GKEHubFeatureMembership
-metadata:
-  name: feature-membership-name # kpt-set: gke-acm-config-mgmt-csr-${cluster-name}
+metadata: # kpt-merge: platform-namespace/feature-membership-name
+  name: feature-membership-name # kpt-set: ${feature-membership-name}
   namespace: platform-namespace # kpt-set: ${platform-namespace}
 spec:
   projectRef:
     external: platform-project-id # kpt-set: ${platform-project-id}
   location: global
   membershipRef:
-    name: membership-name # kpt-set: acm-mem-${cluster-name}
+    name: membership-name # kpt-set: ${membership-name}
   featureRef:
-    name: feature-name # kpt-set: gke-acm-config-mgmt-${cluster-name}
+    name: feature-name # kpt-set: ${feature-name}
   configmanagement:
     version: 1.9.0
     configSync:
@@ -32,16 +32,16 @@ spec:
         syncRepo: https://source.developers.google.com/p/{project_id}/r/{repo} # kpt-set: ${syncRepo}
         syncBranch: main # kpt-set: ${syncBranch}
         policyDir: config/root # kpt-set: ${policyDir}
-        syncWaitSecs: "10"
+        syncWaitSecs: "10" # kpt-set: ${syncWaitSecs}
         syncRev: HEAD # kpt-set: ${syncRev}
         secretType: gcpserviceaccount
         gcpServiceAccountRef:
-          external: sa_name@{project_id}.iam.gserviceaccount.com # kpt-set: ${gcpServiceAccountEmail}
+          external: sa-acm-cluster-name@platform-project-id.iam.gserviceaccount.com # kpt-set: sa-acm-${cluster-name}@${platform-project-id}.iam.gserviceaccount.com
     policyController:
       enabled: true
       exemptableNamespaces:
         - "test-namespace" # kpt-set: ${exemptableNamespaces}
       referentialRulesEnabled: true # kpt-set: ${referentialRulesEnabled}
-      logDeniesEnabled: true
+      logDeniesEnabled: true # kpt-set: ${logDeniesEnabled}
       templateLibraryInstalled: true # kpt-set: ${templateLibraryInstalled}
-      auditIntervalSeconds: "20"
+      auditIntervalSeconds: "20" # kpt-set: ${auditIntervalSeconds}

--- a/catalog/acm/config-mgmt-csr.yaml
+++ b/catalog/acm/config-mgmt-csr.yaml
@@ -14,14 +14,14 @@
 apiVersion: gkehub.cnrm.cloud.google.com/v1beta1
 kind: GKEHubFeatureMembership
 metadata: # kpt-merge: platform-namespace/feature-membership-name
-  name: feature-membership-name # kpt-set: ${feature-membership-name}
+  name: feature-membership-name # kpt-set: gke-acm-config-mgmt-csr-${cluster-name}
   namespace: platform-namespace # kpt-set: ${platform-namespace}
 spec:
   projectRef:
     external: platform-project-id # kpt-set: ${platform-project-id}
   location: global
   membershipRef:
-    name: membership-name # kpt-set: ${membership-name}
+    name: membership-name # kpt-set: acm-mem-${cluster-name}
   featureRef:
     name: feature-name # kpt-set: ${feature-name}
   configmanagement:

--- a/catalog/acm/config-mgmt-iam.yaml
+++ b/catalog/acm/config-mgmt-iam.yaml
@@ -1,0 +1,66 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ACM GCP ServiceAccount (GSA)
+
+# This GSA can be used to grant ACM additional permissions with IAMPartialPolicy
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMServiceAccount
+metadata: # kpt-merge: platform-namespace/sa-acm-cluster-name
+  name: sa-acm-gke-cluster # kpt-set: sa-acm-${cluster-name}
+  namespace: config-control # kpt-set: ${namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/acm/v0.0.1
+    cnrm.cloud.google.com/project-id: platform-project-id # kpt-set: ${platform-project-id}
+spec:
+  displayName: sa-acm-gke-cluster # kpt-set: sa-acm-${cluster-name}
+  description: For use with ACM to provide read access to Cloud Source Repositories
+---
+# Allow ACM Config Sync Kubernetes ServiceAccount (KSA) to use the ACM GSA
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPartialPolicy
+metadata: # kpt-merge: platform-namespace/sa-acm-cluster-name
+  name: sa-acm-gke-cluster # kpt-set: sa-acm-${cluster-name}
+  namespace: config-control # kpt-set: ${namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/acm/v0.0.1
+    cnrm.cloud.google.com/project-id: platform-project-id # kpt-set: ${platform-project-id}
+spec:
+  resourceRef:
+    name: sa-acm-gke-cluster # kpt-set: sa-acm-${cluster-name}
+    apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMServiceAccount
+  bindings:
+    - role: roles/iam.workloadIdentityUser
+      members:
+        - member: serviceAccount:platform-project-id.svc.id.goog[config-management-system/root-reconciler] # kpt-set: serviceAccount:${platform-project-id}.svc.id.goog[config-management-system/root-reconciler]
+---
+# Allow ACM GSA to read from CSR repos in the CSR project
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPartialPolicy
+metadata: # kpt-merge: platform-namespace/source-reader-sync-cluster-name-platform-project-id
+  name: source-reader-sync-cluster-name-platform-project-id # kpt-set: source-reader-sync-${cluster-name}-${platform-project-id}
+  namespace: config-control # kpt-set: ${namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/acm/v0.0.1
+    cnrm.cloud.google.com/project-id: platform-project-id # kpt-set: ${platform-project-id}
+spec:
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: platform-project-id # kpt-set: ${platform-project-id}
+  bindings:
+    - role: roles/source.reader
+      members:
+        - member: serviceAccount:sync-gke-cluster@platform-project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:sa-acm-${cluster-name}@${platform-project-id}.iam.gserviceaccount.com

--- a/catalog/acm/setters.yaml
+++ b/catalog/acm/setters.yaml
@@ -14,33 +14,42 @@
 
 apiVersion: v1
 kind: ConfigMap
-metadata:
+metadata: # kpt-merge: /setters
   name: setters
 data:
   # The name of this cluster
-  cluster-name: cluster-name # kpt-set: ${cluster-name}
-  # The environment (set as a label on the cluster)
-  location: location # kpt-set: ${location}
+  cluster-name: gke-demo # kpt-set: ${cluster-name}
+  # The location for this cluster e.g. us-east4
+  location: us-east4 # kpt-set: ${location}
   # The namespace in which to manage cluster resources
-  platform-namespace: platform-namespace # kpt-set: ${platform-namespace}
+  platform-namespace: config-control # kpt-set: ${platform-namespace}
   # The project in which to manage cluster resources
-  platform-project-id: platform-project-id # kpt-set: ${platform-project-id}
+  platform-project-id: krm-playground-00 # kpt-set: ${platform-project-id}
+  # The name for the GKE Hub Membership in Anthos
+  membership-name: gke-demo-membership # kpt-set: ${membership-name}
+  # The name for the GKE Hub Feature to be enabled for Anthos
+  feature-name: acm # kpt-set: ${feature-name}
+  # The name for the GKE Hub Feature Membership configuration for the registered cluster
+  feature-membership-name: acm-gke-demo-membership # kpt-set: ${feature-membership-name}
   # The URL for the repo for Config Sync
-  syncRepo: https://source.developers.google.com/p/{project_id}/r/{repo} # kpt-set: ${syncRepo}
+  syncRepo: https://source.developers.google.com/p/krm-playground-00/r/gke-bp-deployment # kpt-set: ${syncRepo}
   # The source format for the repo for Config Sync
   sourceFormat: unstructured # kpt-set: ${sourceFormat}
   # The branch to sync resources from for the repo for Config Sync
   syncBranch: main # kpt-set: ${syncBranch}
-  # The GCP service account that with source.reader role to read configs from Cloud Source Repository
-  gcpServiceAccountEmail: sa_name@{project_id}.iam.gserviceaccount.com # kpt-set: ${gcpServiceAccountEmail}
   # The directory in the repository to pull configs from
   policyDir: config/root # kpt-set: ${policyDir}
+  # The wait time in seconds between consecutive syncs
+  syncWaitSecs: "10" # kpt-set: ${syncWaitSecs}
   # The Tag or Hash on the Config Sync repo to checkout
   syncRev: HEAD # kpt-set: ${syncRev}
   # The namespaces to exempt from Policy Controller constraints enforcement
   exemptableNamespaces: test-namespace # kpt-set: ${exemptableNamespaces}
   # The flag to enable the use of referential Constraint Templates
   referentialRulesEnabled: true # kpt-set: ${referentialRulesEnabled}
+  # The flag to enable logging of all denies and dry run failures
+  logDeniesEnabled: true # kpt-set: ${logDeniesEnabled}
   # The flag to install the default template library
   templateLibraryInstalled: true # kpt-set: ${templateLibraryInstalled}
-  
+  # The interval between consecutive Policy Controller audit Scans
+  auditIntervalSeconds: "20" # kpt-set: ${auditIntervalSeconds}

--- a/catalog/acm/setters.yaml
+++ b/catalog/acm/setters.yaml
@@ -18,26 +18,26 @@ metadata: # kpt-merge: /setters
   name: setters
 data:
   # The name of this cluster
-  cluster-name: gke-demo # kpt-set: ${cluster-name}
+  cluster-name: cluster-name # kpt-set: ${cluster-name}
   # The location for this cluster e.g. us-east4
-  location: us-east4 # kpt-set: ${location}
+  location: location # kpt-set: ${location}
   # The namespace in which to manage cluster resources
-  platform-namespace: config-control # kpt-set: ${platform-namespace}
+  platform-namespace: platform-namespace # kpt-set: ${platform-namespace}
   # The project in which to manage cluster resources
-  platform-project-id: krm-playground-00 # kpt-set: ${platform-project-id}
+  platform-project-id: platform-project-id # kpt-set: ${platform-project-id}
   # The name for the GKE Hub Membership in Anthos
-  membership-name: gke-demo-membership # kpt-set: ${membership-name}
+  membership-name: membership-name # kpt-set: ${membership-name}
   # The name for the GKE Hub Feature to be enabled for Anthos
   feature-name: acm # kpt-set: ${feature-name}
   # The name for the GKE Hub Feature Membership configuration for the registered cluster
-  feature-membership-name: acm-gke-demo-membership # kpt-set: ${feature-membership-name}
+  feature-membership-name: feature-membership-name # kpt-set: ${feature-membership-name}
   # The URL for the repo for Config Sync
-  syncRepo: https://source.developers.google.com/p/krm-playground-00/r/gke-bp-deployment # kpt-set: ${syncRepo}
+  syncRepo: https://source.developers.google.com/p/{project_id}/r/{repo} # kpt-set: ${syncRepo}
   # The source format for the repo for Config Sync
   sourceFormat: unstructured # kpt-set: ${sourceFormat}
   # The branch to sync resources from for the repo for Config Sync
   syncBranch: main # kpt-set: ${syncBranch}
-  # The directory in the repository to pull configs from
+  # The directory in the repository to pull configs from e.g. config/root
   policyDir: config/root # kpt-set: ${policyDir}
   # The wait time in seconds between consecutive syncs
   syncWaitSecs: "10" # kpt-set: ${syncWaitSecs}


### PR DESCRIPTION
- Added a new Google Service Account for use with ACM to sync with the repos
- Tied it to Workload Identity
- Added attribution
- Improved naming for resources 